### PR TITLE
chore: keep 16.x only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -41,7 +41,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# Description
Only keep 16.x in the test and build step because it may cancel the sonar cloud scan when the agent runs three version at the same time.

## Types of change

- [x] Others

## Results

N/A
